### PR TITLE
Support for ACTIVE_HIGH sw0 button

### DIFF
--- a/src/system/system.c
+++ b/src/system/system.c
@@ -131,10 +131,14 @@ void configure_sense_pins(void) {
 #endif
 	// Configure sw0 interrupt
 #if BUTTON_EXISTS  // Alternate button if available to use as "reset key"
-	nrf_gpio_cfg_input(NRF_DT_GPIOS_TO_PSEL(DT_ALIAS(sw0), gpios), NRF_GPIO_PIN_PULLUP);
+
+	//Button is already configured as input in sys_button_init
+	const struct gpio_dt_spec button0 = GPIO_DT_SPEC_GET(DT_ALIAS(sw0), gpios);
+	uint32_t active_low = button0.dt_flags & GPIO_ACTIVE_LOW;
+
 	nrf_gpio_cfg_sense_set(
 		NRF_DT_GPIOS_TO_PSEL(DT_ALIAS(sw0), gpios),
-		NRF_GPIO_PIN_SENSE_LOW
+		active_low ? NRF_GPIO_PIN_SENSE_HIGH : NRF_GPIO_PIN_SENSE_LOW
 	);
 	LOG_INF("Configured sw0 interrupt");
 #endif


### PR DESCRIPTION
Deep sleep was configured to always wake up on LOW, which becomes a problem when sw0 is configured as ACTIVE_HIGH with pull downs. This commit makes it so the active level is considered and removes an unneeded pin initializer, which would always enable pull ups